### PR TITLE
changed due to http://tickets.opscode.com/browse/CHEF-3959

### DIFF
--- a/recipes/proxy_apache2.rb
+++ b/recipes/proxy_apache2.rb
@@ -40,7 +40,7 @@ template "#{node[:apache][:dir]}/htpasswd" do
   owner node[:apache][:user]
   group node[:apache][:user]
   mode 0600
-  only_if node[:jenkins][:http_proxy][:basic_auth]
+  only_if { node[:jenkins][:http_proxy][:basic_auth] }
 end
 
 template "#{node[:apache][:dir]}/sites-available/jenkins" do


### PR DESCRIPTION
@brettweavnet had to make this change otherwise we were getting this error. This ticket has more details about the change .... http://tickets.opscode.com/browse/CHEF-3959

This has been tested and is ready to merge.

Our Jenkins fork is way off from what is out in the community now.

```
ArgumentError
-------------
Invalid only_if/not_if command: true (TrueClass)


Cookbook Trace:
---------------
  /var/chef/vendor/cookbooks/jenkins/recipes/proxy_apache2.rb:44:in `block in from_file'
  /var/chef/vendor/cookbooks/jenkins/recipes/proxy_apache2.rb:38:in `from_file'
  /var/chef/vendor/cookbooks/jenkins/recipes/default.rb:174:in `from_file'


Relevant File Content:
----------------------
/var/chef/vendor/cookbooks/jenkins/recipes/proxy_apache2.rb:

 37:  puts node[:jenkins][:http_proxy][:basic_auth]
 38:  template "#{node[:apache][:dir]}/htpasswd" do
 39:    variables( :username => node[:jenkins][:http_proxy][:basic_auth_username],
 40:               :password => node[:jenkins][:http_proxy][:basic_auth_password])
 41:    owner node[:apache][:user]
 42:    group node[:apache][:user]
 43:    mode 0600
 44>>   only_if node[:jenkins][:http_proxy][:basic_auth]
 45:  end
 46:  
 47:  template "#{node[:apache][:dir]}/sites-available/jenkins" do
 48:    source      "apache_jenkins.erb"
 49:    owner       'root'
 50:    group       'root'
 51:    mode        '0644'
 52:    variables(
 53:      :host_name        => host_name

```
