### PR TITLE
use ip rather then hostname for deployment check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,7 +34,8 @@ default[:jenkins][:server][:group] = node[:jenkins][:server][:user]
 
 default[:jenkins][:server][:port] = 8080
 default[:jenkins][:server][:host] = node[:fqdn]
-default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}"
+default[:jenkins][:server][:ip] = node[:ipaddress]
+default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:ip]}:#{node[:jenkins][:server][:port]}"
 
 #download the latest version of plugins, bypassing update center
 #example: ["git", "URLSCM", ...]


### PR DESCRIPTION
Currently, as part of the deployment process there is a check to see if Jenkins is listening by checking hostname:port  the only problem is that when using a http_proxy you need to bypass the proxy for this check. This is difficult to do when using the systems hostname as the URL to check, since you would have to exclude the hostname in the ./config/solo.rb file as noproxy.  A better approach is to use the system ip address, which is easy to exclude the entire range as noproxy="10._._.*"

This is tested and ready to merge.
